### PR TITLE
Improve report code handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ La tabla muestra:
 
 - **WarcraftLogs:**
   - Ingresa a [warcraftlogs.com](https://warcraftlogs.com)
-  - Busca tu reporte utilizando el código proporcionado.
+  - Busca tu reporte utilizando el enlace completo o el código proporcionado.
   - En la sección "Rankings" puedes ver los porcentajes por cada intento.
 
 - **Wipefest:**

--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -248,7 +248,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
         
         <div className="grid gap-4 py-4">
           <div className="flex items-center justify-between mb-2">
-            <Label className="text-sm font-medium">Report Codes</Label>
+            <Label className="text-sm font-medium">Report Links or Codes</Label>
             <Button 
               variant="outline" 
               size="sm" 
@@ -266,7 +266,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
                 value={code}
                 onChange={(e) => updateReportCode(index, e.target.value)}
                 className="flex-1"
-                placeholder="Log report code (e.g. a2bC3d4E)"
+                placeholder="Log report link or code"
               />
               {localReportCodes.length > 1 && (
                 <Button 

--- a/src/services/warcraftLogsApi.ts
+++ b/src/services/warcraftLogsApi.ts
@@ -76,8 +76,18 @@ export interface PlayerAverage {
   };
 }
 
+const extractReportCode = (input: string): string => {
+  if (!input) return '';
+  const trimmed = input.trim();
+  const urlMatch = trimmed.match(/reports\/([a-zA-Z0-9]+)(?=[/#?]|$)/);
+  if (urlMatch) return urlMatch[1];
+  const codeMatch = trimmed.match(/[a-zA-Z0-9]{8,}/);
+  return codeMatch ? codeMatch[0] : trimmed;
+};
+
 export const useWarcraftLogsApi = (initialReportCodes: string[], apiKey: string, targetZone: string, forceRefresh?: number) => {
-  const [reportCodes, setReportCodes] = useState<string[]>(initialReportCodes.filter(Boolean));
+  const sanitizedInitial = initialReportCodes.map(extractReportCode).filter(Boolean);
+  const [reportCodes, setReportCodes] = useState<string[]>(sanitizedInitial);
   const [reportsData, setReportsData] = useState<Record<string, ReportData>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -897,7 +907,8 @@ export const useWarcraftLogsApi = (initialReportCodes: string[], apiKey: string,
 
   // Update report codes
   const updateReportCodes = (newCodes: string[]) => {
-    setReportCodes(newCodes.filter(Boolean));
+    const sanitized = newCodes.map(extractReportCode).filter(Boolean);
+    setReportCodes(sanitized);
   };
 
   // Effect to fetch reports when dependencies change


### PR DESCRIPTION
## Summary
- allow API to parse full Warcraft Logs URLs
- update config panel wording to allow links
- document that links are also valid

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6855b2debc908328a182912ff262afc5